### PR TITLE
55 sameshi

### DIFF
--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="first btn btn-sm btn-ghost m-2">
+<span class="first btn btn-sm btn-circle btn-ghost my-2">
   <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
 </span>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap rounded-full btn btn-sm btn-disabled m-2"><%= t('views.pagination.truncate').html_safe %></span>
+<span class="page gap rounded-full btn btn-sm btn-circle btn-disabled m-2"><%= t('views.pagination.truncate').html_safe %></span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="last btn btn-sm btn-ghost m-2">
+<span class="last btn btn-sm btn-circle btn-ghost my-2">
   <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
 </span>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next btn btn-sm btn-ghost m-2">
+<span class="next btn btn-sm btn-circle btn-ghost my-2">
   <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
 </span>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -9,10 +9,10 @@
 -%>
 <% if page.current? %>
   <span class="page current">
-    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "rounded-full btn btn-sm btn-neutral m-2"} %>
+    <%= link_to_if page.current?, page, url, {remote: remote, rel: page.rel, class: "rounded-full btn btn-sm btn-circle btn-neutral my-2"} %>
   </span>
 <% else %>
   <span class="page">
-    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "rounded-full btn btn-sm btn-ghost m-2"} %>
+    <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "rounded-full btn btn-sm btn-circle btn-ghost my-2"} %>
   </span>
 <% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -9,7 +9,6 @@
 <%= paginator.render do -%>
   <nav class="pagination join" role="navigation" aria-label="pager">
     <%= first_page_tag unless current_page.first? %>
-    <%= prev_page_tag unless current_page.first? %>
     <% each_page do |page| -%>
       <% if page.display_tag? -%>
         <%= page_tag page %>
@@ -18,7 +17,6 @@
       <% end -%>
     <% end -%>
     <% unless current_page.out_of_range? %>
-      <%= next_page_tag unless current_page.last? %>
       <%= last_page_tag unless current_page.last? %>
     <% end %>
   </nav>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,6 +6,6 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="prev btn btn-sm btn-ghost m-2">
+<span class="prev btn btn-sm btn-circle btn-ghost my-2">
   <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
 </span>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -3,7 +3,7 @@
 Kaminari.configure do |config|
   config.default_per_page = 6
   # config.max_per_page = nil
-  # config.window = 4
+  config.window = 2
   # config.outer_window = 0
   # config.left = 0
   # config.right = 0


### PR DESCRIPTION
## ページネーション修正

投稿一覧ページで、ページネーションの広がりによりUIの乱れが生じていた箇所の修正。

- [x] UI（マージン）修正
- [x] next、prevボタン非表示
- [x] 現ページの両隣2件表示に変更

closes #159 